### PR TITLE
Fix case sensitive var name

### DIFF
--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -87,10 +87,10 @@ func unpackSIPAuthData(i interface{}) thousandeyes.SIPAuthData {
 			sipAuthData.Protocol = v.(string)
 		}
 		if k == "sip_proxy" {
-			sipAuthData.SipProxy = v.(string)
+			sipAuthData.SIPProxy = v.(string)
 		}
 		if k == "sip_registrar" {
-			sipAuthData.SipRegistrar = v.(string)
+			sipAuthData.SIPRegistrar = v.(string)
 		}
 		if k == "user" {
 			sipAuthData.User = v.(string)


### PR DESCRIPTION
Failed to build as var name did not match. Case sensitive. 