### PR TITLE
fix(provider): Remove old alert rules data source

### DIFF
--- a/thousandeyes/provider.go
+++ b/thousandeyes/provider.go
@@ -41,7 +41,6 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"thousandeyes_account_group": dataSourceThousandeyesAccountGroup(),
 			"thousandeyes_agent":         dataSourceThousandeyesAgent(),
-			"thousandeyes_alert_rule":    dataSourceThousandeyesAlertRule(),
 			"thousandeyes_bgp_monitor":   dataSourceThousandeyesBGPMonitor(),
 			"thousandeyes_integration":   dataSourceThousandeyesIntegration(),
 		},


### PR DESCRIPTION
It appears this data source definition was re-added by a subsequent commit.

Removing it as it's now replaced with a resource definition.