### PR TITLE
fix(account_group): Fix value name setting

### DIFF
--- a/thousandeyes/data_source_thousandeyes_account_group.go
+++ b/thousandeyes/data_source_thousandeyes_account_group.go
@@ -53,7 +53,7 @@ func dataSourceThousandeyesAccountGroupRead(d *schema.ResourceData, meta interfa
 
 	d.SetId(fmt.Sprint(found.AID))
 	d.Set("name", found.AccountGroupName)
-	d.Set("agent_id", found.AID)
+	d.Set("aid", found.AID)
 
 	return nil
 }

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -670,11 +670,6 @@ var schemas = map[string]*schema.Schema{
 					Description: "Account group ID",
 					Required:    true,
 				},
-				"name": {
-					Type:        schema.TypeString,
-					Description: "Account group name",
-					Optional:    true,
-				},
 			},
 		},
 	},


### PR DESCRIPTION
Values set for retrieved account group objects had wrong names.  This
corrects that.  Additionally, an extraneous schema definition for
shared_with_account_groups name value was removed.