### PR TITLE
fix(bgp_monitor): Fix value name setting

### DIFF
--- a/thousandeyes/data_source_thousandeyes_bgp_monitor.go
+++ b/thousandeyes/data_source_thousandeyes_bgp_monitor.go
@@ -74,8 +74,8 @@ func dataSourceThousandeyesBGPMonitorsRead(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(strconv.Itoa(found.MonitorID))
-	d.Set("rule_name", found.MonitorName)
-	d.Set("rule_id", found.MonitorID)
+	d.Set("monitor_name", found.MonitorName)
+	d.Set("monitor_id", found.MonitorID)
 
 	return nil
 }

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -170,7 +170,7 @@ var schemas = map[string]*schema.Schema{
 				"monitor_id": {
 					Type:        schema.TypeInt,
 					Description: "monitor id",
-					Optional:    true,
+					Required:    true,
 				},
 			},
 		},


### PR DESCRIPTION
Values set for retrieved BGP monitor objects had wrong names.  This
corrects that.  Additionally, sets schema for BGP monitor ID to be
required.