### PR TITLE
fix(alert_rule): Include required fields on update

### DIFF
--- a/thousandeyes/resource_alert_rule.go
+++ b/thousandeyes/resource_alert_rule.go
@@ -42,6 +42,18 @@ func resourceAlertRuleUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	id, _ := strconv.Atoi(d.Id())
 	update := ResourceUpdate(d, &thousandeyes.AlertRule{}).(*thousandeyes.AlertRule)
+	// While most ThousandEyes updates only require updated fields and specifically
+	// disallow some fields on update, Alert Rules actually require a few fields
+	// to be retained on update.
+	// Terraform schema validation should guarantee their existence.
+	update.AlertType = d.Get("alert_type").(string)
+	update.Direction = d.Get("direction").(string)
+	update.Expression = d.Get("expression").(string)
+	update.MinimumSources = d.Get("minimum_sources").(int)
+	update.MinimumSourcesPct = d.Get("minimum_sources_pct").(int)
+	update.RoundsViolatingRequired = d.Get("rounds_violating_required").(int)
+	update.RoundsViolatingOutOf = d.Get("rounds_violating_out_of").(int)
+
 	_, err := client.UpdateAlertRule(id, *update)
 	if err != nil {
 		return err

--- a/thousandeyes/resource_alert_rule.go
+++ b/thousandeyes/resource_alert_rule.go
@@ -53,6 +53,7 @@ func resourceAlertRuleUpdate(d *schema.ResourceData, m interface{}) error {
 	update.MinimumSourcesPct = d.Get("minimum_sources_pct").(int)
 	update.RoundsViolatingRequired = d.Get("rounds_violating_required").(int)
 	update.RoundsViolatingOutOf = d.Get("rounds_violating_out_of").(int)
+	update.RuleName = d.Get("rule_name").(string)
 
 	_, err := client.UpdateAlertRule(id, *update)
 	if err != nil {

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -329,9 +329,10 @@ var schemas = map[string]*schema.Schema{
 		ValidateFunc: validation.IntBetween(0, 1),
 	},
 	"expression": {
-		Type:        schema.TypeString,
-		Description: "Alert rule evaluation expression",
-		Optional:    true,
+		Type:         schema.TypeString,
+		Description:  "Alert rule evaluation expression",
+		Required:     true,
+		ValidateFunc: validation.StringIsNotEmpty,
 	},
 	"follow_redirects": {
 		Type:        schema.TypeInt,


### PR DESCRIPTION
Unlike test updates which disallow certain non-updated fields, an update
for an alert rule requires more than just the updated fields.  This
will add the required fields to the update data.
A schema validation for the expression field is included.