### PR TITLE
fix(label): Include label name on update

### DIFF
--- a/thousandeyes/resource_label.go
+++ b/thousandeyes/resource_label.go
@@ -43,6 +43,10 @@ func resourceGroupLabelUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Label %s", d.Id())
 	id, _ := strconv.Atoi(d.Id())
 	update := ResourceUpdate(d, &thousandeyes.GroupLabel{}).(*thousandeyes.GroupLabel)
+	// While most ThousandEyes updates only require updated fields and specifically
+	// disallow some fields on update, Labels require the label name field to be
+	// retained on update otherwise the call fails.
+	update.Name = d.Get("name").(string)
 	_, err := client.UpdateGroupLabel(id, *update)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently label updates don't work if you want to do something like add an additional agent to a label resource