### PR TITLE
Support building structs from list resources

### DIFF
--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -705,7 +705,8 @@ var schemas = map[string]*schema.Schema{
 		Description: "pull from /agents endpoint	Both the 'agents': [] and the targetAgentID cannot be cloud agents. Can be Enterprise Agent -> Cloud, Cloud -> Enterprise Agent, or Enterprise Agent -> Enterprise Agent",
 	},
 	"target_sip_credentials": {
-		Type:     schema.TypeMap,
+		Type:     schema.TypeList,
+		MaxItems: 1,
 		Required: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -105,6 +105,10 @@ func TestFillValue(t *testing.T) {
 		"testStruct": {
 			Type: schema.TypeMap,
 		},
+		"testStructSlice": {
+			Type: schema.TypeList,
+			Elem: schema.TypeMap,
+		},
 	}
 	d := getReferenceData(testSchemas, attrs)
 
@@ -163,6 +167,20 @@ func TestFillValue(t *testing.T) {
 	if reflect.DeepEqual(testStruct, cmpStruct) != true {
 		t.Errorf("testStruct doesn't match cmpStruct\ntestStruct: %+v\ncmpStruct: %+v", testStruct, cmpStruct)
 	}
+
+	// Struct from slice test
+	refSlice := []map[string]string{
+		refMap,
+	}
+	err = d.Set("testStructSlice", refSlice)
+	if err != nil {
+		t.Errorf("Error setting resourceData for 'testStruct': %+v", err.Error())
+	}
+	testStruct = FillValue(d.Get("testStruct"), refStruct{}).(refStruct)
+	if reflect.DeepEqual(testStruct, cmpStruct) != true {
+		t.Errorf("testStruct doesn't match cmpStruct\ntestStruct: %+v\ncmpStruct: %+v", testStruct, cmpStruct)
+	}
+
 }
 
 func TestUnderscoreToLowerCamelCase(t *testing.T) {


### PR DESCRIPTION
This fixes schema validation for targetSipCredentials, which was
broken by a combination of newer version of Terraform with the new
plugin SDK.

Newer versions of Terraform do not permit declaring map schemas as
resources, meaning that there is no way to validate maps with elements
of disparate types or to validate specific key names in a map.  The
alternatives are to perform schema validtion manually elsewhere, or to
declare them as resources.  Since we already fall back to
resource declarations for lists of maps, repeating the practice seemed
like the least worst option.  Schema validation for this case is done by
declaring the type as a list with a maximum length of 1, and elements
declared as resources.