### PR TITLE
fix: Save remote state correctly for struct fields

### DIFF
--- a/thousandeyes/data_source_thousandeyes_account_group.go
+++ b/thousandeyes/data_source_thousandeyes_account_group.go
@@ -52,8 +52,14 @@ func dataSourceThousandeyesAccountGroupRead(d *schema.ResourceData, meta interfa
 	log.Printf("[INFO] ## Found AccountGroup ID: %d - name: %s", found.AID, found.AccountGroupName)
 
 	d.SetId(fmt.Sprint(found.AID))
-	d.Set("name", found.AccountGroupName)
-	d.Set("aid", found.AID)
+	err = d.Set("name", found.AccountGroupName)
+	if err != nil {
+		return err
+	}
+	err = d.Set("aid", found.AID)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/thousandeyes/data_source_thousandeyes_agent.go
+++ b/thousandeyes/data_source_thousandeyes_agent.go
@@ -56,8 +56,14 @@ func dataSourceThousandeyesAgentRead(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[INFO] ## Found Agent agent_id: %d - name: %s", found.AgentID, found.AgentName)
 
 	d.SetId(fmt.Sprint(found.AgentID))
-	d.Set("agent_name", found.AgentName)
-	d.Set("agent_id", found.AgentID)
+	err = d.Set("agent_name", found.AgentName)
+	if err != nil {
+		return err
+	}
+	err = d.Set("agent_id", found.AgentID)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/thousandeyes/data_source_thousandeyes_bgp_monitor.go
+++ b/thousandeyes/data_source_thousandeyes_bgp_monitor.go
@@ -74,8 +74,14 @@ func dataSourceThousandeyesBGPMonitorsRead(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(strconv.Itoa(found.MonitorID))
-	d.Set("monitor_name", found.MonitorName)
-	d.Set("monitor_id", found.MonitorID)
+	err = d.Set("monitor_name", found.MonitorName)
+	if err != nil {
+		return err
+	}
+	err = d.Set("monitor_id", found.MonitorID)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/thousandeyes/data_source_thousandeyes_integration.go
+++ b/thousandeyes/data_source_thousandeyes_integration.go
@@ -34,7 +34,7 @@ func dataSourceThousandeyesIntegration() *schema.Resource {
 				Description: "(Slack only) Slack #channel or @user",
 			},
 			"integration_id": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "unique ID of the integration",
 			},
@@ -86,8 +86,14 @@ func dataSourceThousandeyesIntegrationRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("unable to locate any integration by name: %s", searchName)
 	}
 	d.SetId(found.IntegrationID)
-	d.Set("integration_name", found.IntegrationName)
-	d.Set("integration_id", found.IntegrationID)
+	err = d.Set("integration_name", found.IntegrationName)
+	if err != nil {
+		return err
+	}
+	err = d.Set("integration_id", found.IntegrationID)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/thousandeyes/provider.go
+++ b/thousandeyes/provider.go
@@ -2,11 +2,16 @@ package thousandeyes
 
 import (
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/william20111/go-thousandeyes"
 )
+
+// Global variable for account group ID, as we must be aware of it in
+// functions that will not have access to it otherwise.
+var account_group_id int
 
 // Provider for module
 func Provider() *schema.Provider {
@@ -61,6 +66,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		AuthToken: d.Get("token").(string),
 		AccountID: d.Get("account_group_id").(string),
 		Timeout:   time.Second * time.Duration(d.Get("timeout").(int)),
+	}
+	var err error
+	if opts.AccountID != "" {
+		account_group_id, err = strconv.Atoi(opts.AccountID)
+		if err != nil {
+			return nil, err
+		}
+
 	}
 	return thousandeyes.NewClient(&opts), nil
 }

--- a/thousandeyes/resource_agent_to_agent.go
+++ b/thousandeyes/resource_agent_to_agent.go
@@ -32,7 +32,10 @@ func resourceAgentAgentRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_agent_to_server.go
+++ b/thousandeyes/resource_agent_to_server.go
@@ -31,7 +31,10 @@ func resourceAgentServerRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_alert_rule.go
+++ b/thousandeyes/resource_alert_rule.go
@@ -32,7 +32,10 @@ func resourceAlertRuleRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_bgp.go
+++ b/thousandeyes/resource_bgp.go
@@ -31,7 +31,10 @@ func resourceBGPRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_dns_server.go
+++ b/thousandeyes/resource_dns_server.go
@@ -31,7 +31,10 @@ func resourceDNSServerRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_dns_trace.go
+++ b/thousandeyes/resource_dns_trace.go
@@ -31,7 +31,10 @@ func resourceDNSTraceRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_dnssec.go
+++ b/thousandeyes/resource_dnssec.go
@@ -35,7 +35,10 @@ func resourceDNSSecRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_ftp_server.go
+++ b/thousandeyes/resource_ftp_server.go
@@ -33,7 +33,10 @@ func resourceFTPServerRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_http_server.go
+++ b/thousandeyes/resource_http_server.go
@@ -31,7 +31,10 @@ func resourceHTTPServerRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_page_load.go
+++ b/thousandeyes/resource_page_load.go
@@ -31,7 +31,10 @@ func resourcePageLoadRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_sip_server.go
+++ b/thousandeyes/resource_sip_server.go
@@ -31,7 +31,10 @@ func resourceSIPServerRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_voice.go
+++ b/thousandeyes/resource_voice.go
@@ -31,7 +31,10 @@ func resourceRTPStreamRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_voice_call.go
+++ b/thousandeyes/resource_voice_call.go
@@ -31,7 +31,10 @@ func resourceVoiceCallRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/resource_web_transactions.go
+++ b/thousandeyes/resource_web_transactions.go
@@ -31,7 +31,10 @@ func resourceWebTransactionRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ResourceRead(d, remote)
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -50,9 +50,173 @@ var schemas = map[string]*schema.Schema{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"agent_id": {
-					Type:        schema.TypeInt,
-					Description: "agent id",
-					Optional:    true,
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"agent_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"agent_state": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"agent_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"country_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"cluster_members": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"agent_state": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"ip_addresses": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"last_seen": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"member_id": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"network": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"prefix": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"public_ip_addresses": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"target_for_tests": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"utilization": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"created_date": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"enabled": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"error_details": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"code": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"description": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"groups": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"builtin": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"group_id": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"type": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"hostname": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"ip_addresses": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"ipv6_policy": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"keep_browser_cache": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"last_seen": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"location": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"network": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"target_for_tests": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"utilization": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"verify_ssl_certificate": {
+					Type:     schema.TypeInt,
+					Optional: true,
 				},
 			},
 		},
@@ -71,17 +235,101 @@ var schemas = map[string]*schema.Schema{
 			},
 		},
 	},
+	"alert_rule_id": {
+		Type:        schema.TypeInt,
+		Description: "ID of  alert rule",
+		Computed:    true,
+	},
 	"alert_rules": {
 		Description: "get ruleId from /alert-rules endpoint. If alertsEnabled is set to 1 and alertRules is not included in a creation/update query, applicable defaults will be used.",
 		Optional:    true,
 		Required:    false,
 		Type:        schema.TypeList,
 		Elem: &schema.Resource{
+			// We need to declare all the fields of AlertRule again here,
+			// to accommodate reads of alert rules declarations returned on test reads.
+			// Pulling them from the regular AlertRule schema declaration
+			// would cause conflict due to them being declared with  `Required: true`
+			// elsewhere.
 			Schema: map[string]*schema.Schema{
+				"alert_rule_id": {
+					Type:        schema.TypeInt,
+					Description: "ID of  alert rule",
+					Computed:    true,
+				},
+				"alert_type": {
+					Description: "Acceptable test types, verbose names",
+					Type:        schema.TypeString,
+					Optional:    true,
+				},
+				"default": {
+					Type:        schema.TypeInt,
+					Description: "to set the rule as a default, set this value to 1.",
+					Optional:    true,
+				},
+				"direction": {
+					// See `direction-alert_rule` below rather than `direction`
+					Type: schema.TypeString,
+					Description: "[TO_TARGET, FROM_TARGET, BIDIRECTIONAL]	Direction of the test (affects how results are shown)",
+					Optional: true,
+				},
+				"expression": {
+					Type:        schema.TypeString,
+					Description: "Alert rule evaluation expression",
+					Optional:    true,
+				},
+				"include_covered_prefixes": {
+					Type:        schema.TypeInt,
+					Description: "set to 1 to include queries for subprefixes detected under this prefix",
+					Optional:    true,
+				},
+				"minimum_sources": {
+					Type:        schema.TypeInt,
+					Description: "The minimum number of agents or monitors that must meet the specified criteria in order to trigger an alert",
+					Optional:    true,
+				},
+				"minimum_sources_pct": {
+					Type:        schema.TypeInt,
+					Description: "The minimum percentage of agents or monitors that must meet the specified criteria in order to trigger an alert",
+					Optional:    true,
+				},
+				"notify_on_clear": {
+					Type:        schema.TypeInt,
+					Description: "set to 1 to trigger the notification when the alert clears.",
+					Optional:    true,
+				},
+				"rounds_violating_mode": {
+					Type:        schema.TypeString,
+					Description: "ANY or EXACT.  EXACT requires that the same agent(s) meet the threshold in consecutive rounds; default is ANY",
+					Optional:    true,
+				},
+				"rounds_violating_out_of": {
+					Type:        schema.TypeInt,
+					Description: "specifies the divisor (Y value) of the “X of Y times” condition in an alert rule.  Minimum value is 1, maximum value is 10.",
+					Optional:    true,
+				},
+				"rounds_violating_required": {
+					Type:        schema.TypeInt,
+					Description: "specifies the numerator (X value) of the “X of Y times” condition in an alert rule.  Minimum value is 1, maximum value is 10. Must be less than or equal to roundsViolatingOutOf",
+					Optional:    true,
+				},
 				"rule_id": {
 					Type:        schema.TypeInt,
 					Description: "If alertsEnabled is set to 1 and alertRules is not included in a creation/update query, applicable defaults will be used.",
 					Optional:    true,
+				},
+				"rule_name": {
+					Type:        schema.TypeString,
+					Description: "name of the alert rule",
+					Optional:    true,
+				},
+				"test_ids": {
+					Type:        schema.TypeList,
+					Description: "Valid test IDs",
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeInt,
+					},
 				},
 			},
 		},
@@ -167,13 +415,34 @@ var schemas = map[string]*schema.Schema{
 		Description: "array of BGP Monitor objects",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"ip_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
 				"monitor_id": {
 					Type:        schema.TypeInt,
 					Description: "monitor id",
 					Required:    true,
 				},
+				"monitor_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"monitor_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"network": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
 			},
 		},
+	},
+	"builtin": {
+		Type:        schema.TypeInt,
+		Description: "1 for built-in labels, and 0 for user-created labels. Note that built-in labels are read-only",
+		Computed:    true,
 	},
 	"client_certificate": {
 		Type:        schema.TypeString,
@@ -269,6 +538,10 @@ var schemas = map[string]*schema.Schema{
 					Description: "DNS Server name",
 					Optional:    true,
 				},
+				"server_id": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
 			},
 		},
 	},
@@ -352,7 +625,29 @@ var schemas = map[string]*schema.Schema{
 		Description: "array of label objects",
 		Optional:    true,
 		Elem: &schema.Resource{
+			// Schema definition here is to support group objects returned from
+			// reads of test resources.
 			Schema: map[string]*schema.Schema{
+				"agents": {
+					// See `agents-label` rather than `agents`
+					Type:        schema.TypeList,
+					Description: "agents to use ",
+					Optional:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"agent_id": {
+								Type:        schema.TypeInt,
+								Description: "agent id",
+								Optional:    true,
+							},
+						},
+					},
+				},
+				"builtin": {
+					Type:        schema.TypeInt,
+					Description: "1 for built-in labels, and 0 for user-created labels. Note that built-in labels are read-only",
+					Computed:    true,
+				},
 				"group_id": {
 					Type:        schema.TypeInt,
 					Description: "Unique ID of the label",
@@ -361,6 +656,26 @@ var schemas = map[string]*schema.Schema{
 				"name": {
 					Type:        schema.TypeString,
 					Description: "Name of the label",
+					Optional:    true,
+				},
+				"tests": {
+					Type:        schema.TypeList,
+					Description: "list of tests",
+					Optional:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"test_id": {
+								Type:        schema.TypeInt,
+								Description: "test id",
+								Optional:    true,
+							},
+						},
+					},
+				},
+				"type": {
+					// See `type-label` rather than `type`
+					Type:        schema.TypeString,
+					Description: "Type of label (tests, agents, endpoint_tests, or endpoint_agents",
 					Optional:    true,
 				},
 			},
@@ -660,6 +975,11 @@ var schemas = map[string]*schema.Schema{
 					Type:        schema.TypeInt,
 					Description: "Account group ID",
 					Required:    true,
+				},
+				"name": {
+					Type:        schema.TypeString,
+					Description: "Name of account",
+					Optional:    true,
 				},
 			},
 		},


### PR DESCRIPTION
State for fields which were instances of other structs was previously
not saved correctly, due to Terraform being unable to match the JSON
field names to the correct schema.
Four pieces are involved in addressing this problem:
- on reads, build an equivalent map with correct names for resource
fields that happen to be structs, via type inspection as we do for
writes
- specify schema for details in nested fields
- handle reads for extraneous detail fields or inconsistent data types as special
  cases
- make error checking for reads more thorough so these problems are not missed in the
  future